### PR TITLE
Add AbstractEntityDtoMapper

### DIFF
--- a/src/main/java/com/ita/if103java/ims/mapper/AbstractEntityDtoMapper.java
+++ b/src/main/java/com/ita/if103java/ims/mapper/AbstractEntityDtoMapper.java
@@ -1,0 +1,18 @@
+package com.ita.if103java.ims.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class AbstractEntityDtoMapper<E, D> {
+    public abstract E toEntity(D dto);
+
+    public abstract D toDto(E entity);
+
+    public List<E> toEntityList(List<D> dtoList) {
+        return dtoList.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+
+    public List<D> toDtoList(List<E> entityList) {
+        return entityList.stream().map(this::toDto).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
To avoid code duplication we'd able to use the next way
```java
public class SavedItemDtoMapper extends AbstractEntityDtoMapper<SavedItem, SavedItemDto> {
    @Override
    public SavedItem toEntity(SavedItemDto dto) {
        SavedItem savedItem = new SavedItem();
        savedItem.setWarehouseId(dto.getIdWarehouse());
        savedItem.setQuantity(dto.getQuantity());
        savedItem.setItemId(dto.getItemId());
        return savedItem;
    }

    @Override
    public SavedItemDto toDto(SavedItem entity) {
        SavedItemDto savedItemDto = new SavedItemDto();
        savedItemDto.setIdWarehouse(entity.getWarehouseId());
        savedItemDto.setItemId(entity.getItemId());
        savedItemDto.setQuantity(entity.getQuantity());
        return savedItemDto;
    }
}

```